### PR TITLE
Bump node to v8; Allow programs to run as root right off the bat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
   echo "deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 RUN apt-get update && apt-get upgrade -y && apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - # Will run `apt-get update` again automatically
 RUN apt-get install -y nodejs \
   git zip unzip balance libpcap-dev tar \
   build-essential \
@@ -17,7 +17,10 @@ RUN apt-get install -y nodejs \
   sudo \
   mongodb-org-tools
 
-COPY start.sh /start.sh
+# Install build tools
+RUN npm config set registry https://registry.npmjs.org/ 2> /dev/null
+RUN npm install -g grunt 2> /dev/null
+RUN npm install -g bower 2> /dev/null
 
 # Replace 1000 with your user / group id
 RUN export uid=1000 gid=1000 && \
@@ -27,10 +30,8 @@ RUN export uid=1000 gid=1000 && \
     echo "developer ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/developer && \
     chmod 0440 /etc/sudoers.d/developer && \
     chown ${uid}:${gid} -R /home/developer
-RUN npm config set registry https://registry.npmjs.org/ 2> /dev/null
-RUN npm install -g grunt 2> /dev/null
-RUN npm install -g bower 2> /dev/null
 USER developer
 WORKDIR /home/developer
 
+COPY start.sh /start.sh
 ENTRYPOINT ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -66,7 +66,9 @@ if (( RESET != 0 )); then
 fi
 
 if (( $# == 0 )); then
-	/bin/bash 
+	/bin/bash
+elif [[ -z "${RUN_AS_SUDO}" || "0" == "${RUN_AS_SUDO}" ]]; then
+    exec "${@}"
 else
-	exec "${@}"	
+	sudo "${@}"
 fi

--- a/start.sh
+++ b/start.sh
@@ -67,7 +67,7 @@ fi
 
 if (( $# == 0 )); then
 	/bin/bash
-elif [[ -z "${RUN_AS_SUDO}" || "0" == "${RUN_AS_SUDO}" ]]; then
+elif [[ -z "${RUN_AS_ROOT}" || "0" == "${RUN_AS_ROOT}" ]]; then
     exec "${@}"
 else
 	sudo "${@}"


### PR DESCRIPTION
Adding in the sudo feature allows for easy debugging from IDEs like
IntelliJ and WebStorm, which will want to start nodejs directly (they
don't provide a way to say "run nodejs as `sudo nodejs`").