### PR TITLE
Revert "[SVM-1117] Install tools necessary to run SVM regression tests"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,12 @@ RUN apt-get install -y nodejs \
   rpm createrepo \
   yum-utils \
   sudo \
-  mongodb-org-tools \
-  python3-pip python3-requests
+  mongodb-org-tools
 
 # Install build tools
 RUN npm config set registry https://registry.npmjs.org/ 2> /dev/null
 RUN npm install -g grunt 2> /dev/null
 RUN npm install -g bower 2> /dev/null
-
-RUN pip3 install selenium boto3
 
 # Replace 1000 with your user / group id
 RUN export uid=1000 gid=1000 && \


### PR DESCRIPTION
This reverts commit 58ad5ff

Soooo.... I might have made a mistake. I thought that the torchwood-ci Docker image should be replaced with toolchain-web, but I was wrong. torchwood-ci (found inside the torchwood repository) is based off of a selenium Docker image and provides the ability to do "headless" Selenium tests. Because of that, this repo never should have been touched.